### PR TITLE
Fix Windows compatibility issues.

### DIFF
--- a/include/tao/config/internal/configurator.hpp
+++ b/include/tao/config/internal/configurator.hpp
@@ -57,7 +57,9 @@ namespace tao::config::internal
          { "msgpack", internal::make_extension( internal::msgpack_function ) },
          // "parse" does not return a single value.
          { "read", internal::read_extension },
+#if !defined( _MSC_VER )
          { "shell", internal::shell_extension },
+#endif
          { "split", internal::split_extension },
          { "string", internal::make_extension( internal::string_function ) },
          { "ubjson", internal::make_extension( internal::ubjson_function ) }

--- a/include/tao/config/internal/inner_extensions.hpp
+++ b/include/tao/config/internal/inner_extensions.hpp
@@ -173,6 +173,7 @@ namespace tao::config::internal
       throw pegtl::parse_error( format( __FILE__, __LINE__, "require string as filename", { st.temporary.type() } ), pos );
    }
 
+#if !defined( _MSC_VER )
    inline void shell_extension( pegtl_input_t& in, state& st )
    {
       const auto pos = in.position();
@@ -191,6 +192,7 @@ namespace tao::config::internal
       }
       throw pegtl::parse_error( format( __FILE__, __LINE__, "require string for shell command", { st.temporary.type() } ), pos );
    }
+#endif
 
    // clang-format off
    struct split_plus_ws : pegtl::plus< pegtl::space > {};

--- a/include/tao/config/internal/phase2_add.hpp
+++ b/include/tao/config/internal/phase2_add.hpp
@@ -13,6 +13,12 @@
 
 namespace tao::config::internal
 {
+#if defined( __GNUC__ ) || defined( __clang__ )
+   using max_int_t = __int128_t;
+#else
+   using max_int_t = std::int64_t;
+#endif
+
    struct overflow_error
    {
    };
@@ -50,7 +56,7 @@ namespace tao::config::internal
          l.assign( l.template as< double >() + r.get_double() );
          return;
       }
-      __int128_t t = 0;
+      max_int_t t = 0;
 
       if( l.is_signed() ) {
          t += l.get_signed();
@@ -71,13 +77,13 @@ namespace tao::config::internal
          throw addition_error{ l.type(), r.type() };
       }
       if( t >= 0 ) {
-         if( t != __int128_t( std::uint64_t( t ) ) ) {
+         if( t != max_int_t( std::uint64_t( t ) ) ) {
             throw overflow_error();
          }
          l.assign( std::uint64_t( t ) );
       }
       else {
-         if( t != __int128_t( std::int64_t( t ) ) ) {
+         if( t != max_int_t( std::int64_t( t ) ) ) {
             throw overflow_error();
          }
          l.assign( std::int64_t( t ) );

--- a/include/tao/config/internal/system.hpp
+++ b/include/tao/config/internal/system.hpp
@@ -48,6 +48,7 @@ namespace tao::config::internal
       return std::nullopt;
    }
 
+#if !defined( _MSC_VER )
    inline std::string shell_popen_throws( const pegtl::position& pos, const std::string& c )
    {
       errno = 0;
@@ -65,6 +66,7 @@ namespace tao::config::internal
       }
       return r;
    }
+#endif
 
 }  // namespace tao::config::internal
 

--- a/include/tao/config/schema/internal/iless.hpp
+++ b/include/tao/config/schema/internal/iless.hpp
@@ -5,7 +5,13 @@
 #define TAO_CONFIG_SCHEMA_INTERNAL_ILESS_HPP
 
 #include <string_view>
+
+#if defined( _MSC_VER )
+#include <string.h>
+#define strncasecmp _strnicmp
+#else
 #include <strings.h>
+#endif
 
 namespace tao::config::schema::internal
 {
@@ -14,7 +20,7 @@ namespace tao::config::schema::internal
       // TODO: Compare international strings (Unicode, using ICU)
       bool operator()( const std::string_view lhs, const std::string_view rhs ) const noexcept
       {
-         const auto d = ::strncasecmp( lhs.begin(), rhs.begin(), ( std::min )( lhs.size(), rhs.size() ) );
+         const auto d = strncasecmp( &( *lhs.begin() ), &( *rhs.begin() ), ( std::min )( lhs.size(), rhs.size() ) );
          return ( d < 0 ) || ( ( d == 0 ) && ( lhs.size() < rhs.size() ) );
       }
    };


### PR DESCRIPTION
BTW - the MSVC compiler issues a lot of warnings:
```
config\include\tao\config\internal\member_extensions.hpp(166): warning C4715: 'tao::config::internal::temporary_compute_current_prefix': not all control paths return a value
config\include\tao\config\internal\phase1_erase.hpp(218): warning C4715: 'tao::config::internal::phase1_erase': not all control paths return a value
config\include\tao\config\internal\phase1_access.hpp(162): warning C4715: 'tao::config::internal::phase1_access': not all control paths return a value
config\include\tao\config\internal\entry.hpp(282): warning C4715: 'tao::config::internal::entry::position': not all control paths return a value
config\include\tao\config\internal\phase1_erase.hpp(99): warning C4715: 'tao::config::internal::phase1_erase': not all control paths return a value
config\include\tao\config\internal\phase1_erase.hpp(182): warning C4715: 'tao::config::internal::phase1_erase': not all control paths return a value
config\include\tao\config\internal\phase2_process.hpp(233): warning C4715: 'tao::config::internal::phase2_processor::process_entry': not all control paths return a value
config\include\tao\config\internal\phase1_access.hpp(76): warning C4715: 'tao::config::internal::phase1_access_impl': not all control paths return a value
config\include\tao\config\access.hpp(76): warning C4715: 'tao::config::access<tao::config::internal::value_traits>': not all control paths return a value
config\include\tao\config\internal\phase2_access.hpp(63): warning C4715: 'tao::config::internal::phase2_access_down': not all control paths return a value
config\include\tao\config\internal\phase2_access.hpp(45): warning C4715: 'tao::config::internal::phase2_access_down': not all control paths return a value
config\include\tao\config\internal\phase1_assign.hpp(111): warning C4715: 'tao::config::internal::phase1_assign': not all control paths return a value
config\include\tao\config\internal\phase1_assign.hpp(87): warning C4715: 'tao::config::internal::phase1_assign': not all control paths return a value
```