### PR TITLE
Fix cmake export error

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -69,7 +69,7 @@ if(TAOCPP_CONFIG_INSTALL)
   write_basic_package_version_file(${PROJECT_NAME}-config-version.cmake COMPATIBILITY SameMajorVersion)
 
   # install and export target
-  install(TARGETS taocpp-config EXPORT ${PROJECT_NAME}-targets)
+  install(TARGETS taocpp-config taocpp-json EXPORT ${PROJECT_NAME}-targets)
   install(FILES
     ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}-config.cmake
     ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}-config-version.cmake


### PR DESCRIPTION
Quick fix for: `CMake Error: install(EXPORT "taocpp-config-targets" ...) includes target "taocpp-config" which requires target "taocpp-json" that is not in any export set.`

At the moment it will break the build if you import taocpp-json via find_package(). I will figured out to fix this also.