### PR TITLE
Improved cmake build to build without to checkout "external/json" manually

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.8...3.19)
+cmake_minimum_required(VERSION 3.11...3.19)
 
 project(taocpp-config VERSION 1.0.0 LANGUAGES CXX)
 
@@ -24,19 +24,42 @@ target_include_directories(taocpp-config INTERFACE
 # require C++17
 target_compile_features(taocpp-config INTERFACE cxx_std_17)
 
+option(TAOCPP_CONFIG_INSTALL "Generate the install target" ${TAOCPP_CONFIG_IS_MAIN_PROJECT})
+
 # find a suitable taoJSON
 set(TAOCPP_CONFIG_JSON_MIN_VERSION 1.0.0)
 find_package(taocpp-json ${TAOCPP_CONFIG_JSON_MIN_VERSION} QUIET CONFIG)
 if(NOT taocpp-json_FOUND)
-  # if a compatible version of taoJSON is not already installed, build and install it from the submodule directory
-  message(STATUS "Adding taoJSON as submodule from external/json")
-  set(TAOCPP_JSON_INSTALL_INCLUDE_DIR ${CMAKE_INSTALL_INCLUDEDIR} CACHE STRING "Override taoJSON include install directory")
-  set(TAOCPP_JSON_INSTALL_CMAKE_DIR ${CMAKE_INSTALL_DATAROOTDIR}/json/cmake CACHE STRING "Override taoJSON cmake install directory")
-  add_subdirectory(external/json)
+  if(EXISTS external/json/CMakeLists.txt)
+    # if a compatible version of taoJSON is not already installed, build and install it from the submodule directory
+    message(STATUS "Adding taoJSON as submodule from external/json")
+    set(TAOCPP_JSON_INSTALL_INCLUDE_DIR ${CMAKE_INSTALL_INCLUDEDIR} CACHE STRING "Override taoJSON include install directory")
+    set(TAOCPP_JSON_INSTALL_CMAKE_DIR ${CMAKE_INSTALL_DATAROOTDIR}/json/cmake CACHE STRING "Override taoJSON cmake install directory")
+    add_subdirectory(external/json)
+  else()
+    include(FetchContent)
+    FetchContent_Declare(
+        taocpp-json
+        GIT_REPOSITORY https://github.com/taocpp/json.git
+        GIT_TAG        master
+      )
+    FetchContent_MakeAvailable(taocpp-json)
+  endif()
+  if(TAOCPP_CONFIG_INSTALL)
+    # install and export target
+    install(TARGETS taocpp-config taocpp-json EXPORT ${PROJECT_NAME}-targets)
+  endif()
+  # add taoJSON as a dependency
+  target_link_libraries(taocpp-config INTERFACE taocpp::json)
+else()
+  if(TAOCPP_CONFIG_INSTALL)
+    # install and export target
+    install(TARGETS taocpp-config EXPORT ${PROJECT_NAME}-targets)
+  endif()
+  # add taoJSON as a dependency
+  target_link_libraries(taocpp-config INTERFACE taocpp::taocpp-json)
 endif()
 
-# add taoJSON as a dependency
-target_link_libraries(taocpp-config INTERFACE taocpp::json)
 
 # testing
 option(TAOCPP_CONFIG_BUILD_TESTS "Build test programs" ${TAOCPP_CONFIG_IS_MAIN_PROJECT})
@@ -51,7 +74,6 @@ if(TAOCPP_CONFIG_BUILD_EXAMPLES)
   add_subdirectory(src/example/config)
 endif()
 
-option(TAOCPP_CONFIG_INSTALL "Generate the install target" ${TAOCPP_CONFIG_IS_MAIN_PROJECT})
 if(TAOCPP_CONFIG_INSTALL)
   include(CMakePackageConfigHelpers)
 
@@ -68,8 +90,6 @@ if(TAOCPP_CONFIG_INSTALL)
   # Enable version checks in find_package
   write_basic_package_version_file(${PROJECT_NAME}-config-version.cmake COMPATIBILITY SameMajorVersion)
 
-  # install and export target
-  install(TARGETS taocpp-config taocpp-json EXPORT ${PROJECT_NAME}-targets)
   install(FILES
     ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}-config.cmake
     ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}-config-version.cmake

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,7 +37,7 @@ if(NOT taocpp-json_FOUND)
     set(TAOCPP_JSON_INSTALL_CMAKE_DIR ${CMAKE_INSTALL_DATAROOTDIR}/json/cmake CACHE STRING "Override taoJSON cmake install directory")
     add_subdirectory(external/json)
   else()
-    if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.11)
+    if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.14.4)
       include(FetchContent)
       FetchContent_Declare(
         taocpp-json

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.11...3.19)
+cmake_minimum_required(VERSION 3.8...3.19)
 
 project(taocpp-config VERSION 1.0.0 LANGUAGES CXX)
 
@@ -37,13 +37,17 @@ if(NOT taocpp-json_FOUND)
     set(TAOCPP_JSON_INSTALL_CMAKE_DIR ${CMAKE_INSTALL_DATAROOTDIR}/json/cmake CACHE STRING "Override taoJSON cmake install directory")
     add_subdirectory(external/json)
   else()
-    include(FetchContent)
-    FetchContent_Declare(
+    if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.11)
+      include(FetchContent)
+      FetchContent_Declare(
         taocpp-json
         GIT_REPOSITORY https://github.com/taocpp/json.git
         GIT_TAG        master
       )
-    FetchContent_MakeAvailable(taocpp-json)
+      FetchContent_MakeAvailable(taocpp-json)
+    else()
+      message(FATAL_ERROR "taoJSON headers are not found!\nInstall taoJSON OR\ncheckout the taoJSON project manually into external/json OR\nuse cmake 3.11 or above")
+    endif()
   endif()
   if(TAOCPP_CONFIG_INSTALL)
     # install and export target


### PR DESCRIPTION
This PR will fix the problem, if you would like to build these project against an already installed JSON "lib"/header.
Also I implemented a solution to "fetch" the sources without to fetch the sources "manually" into `external/json`