### PR TITLE
Fix workflow failure for older compilers on Linux

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -57,7 +57,7 @@ jobs:
           - clang++-9
         build_type: [Debug, Release]
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     env:
       CXX: ${{ matrix.compiler }}


### PR DESCRIPTION
Those older compilers are not available on the `ubuntu-latest` runner images, because that currently is Ubuntu 22.04. However, they are available on Ubuntu 20.04, so we can use that instead.

For an example of the failure see https://github.com/taocpp/config/actions/runs/3881406136/jobs/6620377486. It fails on Ubuntu 22.04, because there is no corresponding package to install for the compiler. However, it worked on earlier runs that ran on Ubuntu 20.04. Therefore, the switch to `ubuntu-20.04` should fix the `linux-old` workflow.

_(It's basically the same as https://github.com/taocpp/json/pull/129, just for taocpp/config.)_