### PR TITLE
[infrastructure] Update Codecov usage

### DIFF
--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -30,5 +30,6 @@ jobs:
     - working-directory: build/
       run: ctest --output-on-failure
 
-    - working-directory: build/
-      run: bash <(curl -s https://codecov.io/bash)
+    - uses: codecov/codecov-action@v5
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
Similar to https://github.com/taocpp/PEGTL/pull/374

@ColinH @d-frey I don't access to https://github.com/taocpp/config settings, so I can't add the Codecov secret Token.

Could you please add it? Need to copy the token listed in https://app.codecov.io/gh/taocpp/config/config/general

Then add it to https://github.com/taocpp/config/settings/secrets/actions by clicking on "New repository secret". The expected variable name is `CODECOV_TOKEN`.